### PR TITLE
Replace deprecated URLs with demo.seleniumeasy

### DIFF
--- a/1/main.py
+++ b/1/main.py
@@ -3,7 +3,7 @@ from selenium import webdriver
 
 os.environ['PATH'] += r"C:/SeleniumDrivers"
 driver = webdriver.Chrome()
-driver.get("https://www.seleniumeasy.com/test/jquery-download-progress-bar-demo.html")
+driver.get("https://demo.seleniumeasy.com/jquery-download-progress-bar-demo.html")
 driver.implicitly_wait(30)
 my_element = driver.find_element_by_id('downloadButton')
 my_element.click()

--- a/2/main.py
+++ b/2/main.py
@@ -7,7 +7,7 @@ from selenium.webdriver.support import expected_conditions as EC
 
 os.environ['PATH'] += r"C:/SeleniumDrivers"
 driver = webdriver.Chrome()
-driver.get("https://www.seleniumeasy.com/test/jquery-download-progress-bar-demo.html")
+driver.get("https://demo.seleniumeasy.com/jquery-download-progress-bar-demo.html")
 driver.implicitly_wait(8)
 my_element = driver.find_element_by_id('downloadButton')
 my_element.click()

--- a/3/main.py
+++ b/3/main.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 os.environ['PATH'] += r"C:/SeleniumDrivers"
 driver = webdriver.Chrome()
 
-driver.get('https://www.seleniumeasy.com/test/basic-first-form-demo.html')
+driver.get('https://demo.seleniumeasy.com/jquery-download-progress-bar-demo.html')
 driver.implicitly_wait(5)
 try:
     no_button = driver.find_element_by_class_name('at-cm-no-button')


### PR DESCRIPTION
Hey Jim,

This pull request addresses deprecated URLs in the codebase, updating them to point to the current and functional demo.seleniumeasy website. The previous URLs were no longer valid due to the deprecation of the seleniumeasy website. By making these changes, we ensure that the links within the project remain accurate and accessible for users.