### PR TITLE
Update deprecated find_element_by_* commands to find_element(By.*, ' ')

### DIFF
--- a/1/main.py
+++ b/1/main.py
@@ -1,9 +1,10 @@
 import os
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 
 os.environ['PATH'] += r"C:/SeleniumDrivers"
 driver = webdriver.Chrome()
 driver.get("https://www.seleniumeasy.com/test/jquery-download-progress-bar-demo.html")
 driver.implicitly_wait(30)
-my_element = driver.find_element_by_id('downloadButton')
+my_element = driver.find_element(By.ID, 'downloadButton')
 my_element.click()

--- a/2/main.py
+++ b/2/main.py
@@ -9,7 +9,7 @@ os.environ['PATH'] += r"C:/SeleniumDrivers"
 driver = webdriver.Chrome()
 driver.get("https://www.seleniumeasy.com/test/jquery-download-progress-bar-demo.html")
 driver.implicitly_wait(8)
-my_element = driver.find_element_by_id('downloadButton')
+my_element = driver.find_element(By.ID, 'downloadButton')
 my_element.click()
 
 WebDriverWait(driver, 30).until(

--- a/3/main.py
+++ b/3/main.py
@@ -13,11 +13,11 @@ try:
 except:
     print('No element with this class name. Skipping ....')
 
-sum1 = driver.find_element_by_id('sum1')
-sum2 = driver.find_element_by_id('sum2')
+sum1 = driver.find_element(By.ID, 'sum1')
+sum2 = driver.find_element(By.ID, 'sum2')
 
 sum1.send_keys(Keys.NUMPAD1, Keys.NUMPAD5)
 sum2.send_keys(15)
 
-btn = driver.find_element_by_css_selector('button[onclick="return total()"]')
+btn = driver.find_element(By.CSS_SELECTOR, 'button[onclick="return total()"]')
 btn.click()

--- a/Bot Project/05 - Deal Searching Part 1/booking/booking.py
+++ b/Bot Project/05 - Deal Searching Part 1/booking/booking.py
@@ -1,6 +1,7 @@
 import booking.constants as const
 import os
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 
 
 class Booking(webdriver.Chrome):
@@ -21,23 +22,23 @@ class Booking(webdriver.Chrome):
         self.get(const.BASE_URL)
 
     def change_currency(self, currency=None):
-        currency_element = self.find_element_by_css_selector(
+        currency_element = self.find_element(By.CSS_SELECTOR,
             'button[data-tooltip-text="Choose your currency"]'
         )
         currency_element.click()
 
-        selected_currency_element = self.find_element_by_css_selector(
+        selected_currency_element = self.find_element(By.CSS_SELECTOR,
             f'a[data-modal-header-async-url-param*="selected_currency={currency}"]'
         )
         selected_currency_element.click()
 
 
     def select_place_to_go(self, place_to_go):
-        search_field = self.find_element_by_id('ss')
+        search_field = self.find_element(By.ID, 'ss')
         search_field.clear()
         search_field.send_keys(place_to_go)
 
-        first_result = self.find_element_by_css_selector(
+        first_result = self.find_element(By.CSS_SELECTOR,
             'li[data-i="0"]'
         )
         first_result.click()

--- a/Bot Project/06 - Deal Searching Part 2/booking/booking.py
+++ b/Bot Project/06 - Deal Searching Part 2/booking/booking.py
@@ -2,6 +2,7 @@ import booking.constants as const
 import os
 from selenium import webdriver
 from booking.booking_filtration import BookingFiltration
+from selenium.webdriver.common.by import By
 
 
 class Booking(webdriver.Chrome):
@@ -22,50 +23,51 @@ class Booking(webdriver.Chrome):
         self.get(const.BASE_URL)
 
     def change_currency(self, currency=None):
-        currency_element = self.find_element_by_css_selector(
+        currency_element = self.find_element(By.CSS_SELECTOR,
             'button[data-tooltip-text="Choose your currency"]'
         )
         currency_element.click()
 
-        selected_currency_element = self.find_element_by_css_selector(
+        selected_currency_element = self.find_element(By.CSS_SELECTOR,
             f'a[data-modal-header-async-url-param*="selected_currency={currency}"]'
         )
         selected_currency_element.click()
 
 
     def select_place_to_go(self, place_to_go):
-        search_field = self.find_element_by_id('ss')
+        search_field = self.find_element(By.ID, 'ss')
         search_field.clear()
         search_field.send_keys(place_to_go)
 
-        first_result = self.find_element_by_css_selector(
+        first_result = self.find_element(By.CSS_SELECTOR,
             'li[data-i="0"]'
         )
         first_result.click()
 
     def select_dates(self, check_in_date, check_out_date):
-        check_in_element = self.find_element_by_css_selector(
+        check_in_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_in_date}"]'
         )
         check_in_element.click()
 
-        check_out_element = self.find_element_by_css_selector(
+        check_out_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_out_date}"]'
         )
         check_out_element.click()
 
     def select_adults(self, count=1):
-        selection_element = self.find_element_by_id('xp__guests__toggle')
+        selection_element = self.find_element(By.ID,
+            'xp__guests__toggle')
         selection_element.click()
 
         while True:
-            decrease_adults_element = self.find_element_by_css_selector(
+            decrease_adults_element = self.find_element(By.CSS_SELECTOR,
                 'button[aria-label="Decrease number of Adults"]'
             )
             decrease_adults_element.click()
             #If the value of adults reaches 1, then we should get out
             #of the while loop
-            adults_value_element = self.find_element_by_id('group_adults')
+            adults_value_element = self.find_element(By.ID, 'group_adults')
             adults_value = adults_value_element.get_attribute(
                 'value'
             ) # Should give back the adults count
@@ -73,7 +75,7 @@ class Booking(webdriver.Chrome):
             if int(adults_value) == 1:
                 break
 
-        increase_button_element = self.find_element_by_css_selector(
+        increase_button_element = self.find_element(By.ID,
             'button[aria-label="Increase number of Adults"]'
         )
 
@@ -81,7 +83,7 @@ class Booking(webdriver.Chrome):
             increase_button_element.click()
 
     def click_search(self):
-        search_button = self.find_element_by_css_selector(
+        search_button = self.find_element(By.CSS_SELECTOR,
             'button[type="submit"]'
         )
         search_button.click()

--- a/Bot Project/07 - Booking Filtrations/booking/booking.py
+++ b/Bot Project/07 - Booking Filtrations/booking/booking.py
@@ -1,6 +1,7 @@
 import booking.constants as const
 import os
 from selenium import webdriver
+from selenium.webdriver.common.By import By
 from booking.booking_filtration import BookingFiltration
 
 
@@ -22,50 +23,50 @@ class Booking(webdriver.Chrome):
         self.get(const.BASE_URL)
 
     def change_currency(self, currency=None):
-        currency_element = self.find_element_by_css_selector(
+        currency_element = self.find_element(By.CSS_SELECTOR,
             'button[data-tooltip-text="Choose your currency"]'
         )
         currency_element.click()
 
-        selected_currency_element = self.find_element_by_css_selector(
+        selected_currency_element = self.find_element(By.CSS_SELECTOR,
             f'a[data-modal-header-async-url-param*="selected_currency={currency}"]'
         )
         selected_currency_element.click()
 
 
     def select_place_to_go(self, place_to_go):
-        search_field = self.find_element_by_id('ss')
+        search_field = self.find_element(By.ID, 'ss')
         search_field.clear()
         search_field.send_keys(place_to_go)
 
-        first_result = self.find_element_by_css_selector(
+        first_result = self.find_element(By.CSS_SELECTOR
             'li[data-i="0"]'
         )
         first_result.click()
 
     def select_dates(self, check_in_date, check_out_date):
-        check_in_element = self.find_element_by_css_selector(
+        check_in_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_in_date}"]'
         )
         check_in_element.click()
 
-        check_out_element = self.find_element_by_css_selector(
+        check_out_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_out_date}"]'
         )
         check_out_element.click()
 
     def select_adults(self, count=1):
-        selection_element = self.find_element_by_id('xp__guests__toggle')
+        selection_element = self.find_element(By.ID, 'xp__guests__toggle')
         selection_element.click()
 
         while True:
-            decrease_adults_element = self.find_element_by_css_selector(
+            decrease_adults_element = self.find_element(By.CSS_SELECTOR,
                 'button[aria-label="Decrease number of Adults"]'
             )
             decrease_adults_element.click()
             #If the value of adults reaches 1, then we should get out
             #of the while loop
-            adults_value_element = self.find_element_by_id('group_adults')
+            adults_value_element = self.find_element(By.ID, 'group_adults')
             adults_value = adults_value_element.get_attribute(
                 'value'
             ) # Should give back the adults count
@@ -73,7 +74,7 @@ class Booking(webdriver.Chrome):
             if int(adults_value) == 1:
                 break
 
-        increase_button_element = self.find_element_by_css_selector(
+        increase_button_element = self.find_element(By.CSS_SELECTOR,
             'button[aria-label="Increase number of Adults"]'
         )
 
@@ -81,7 +82,7 @@ class Booking(webdriver.Chrome):
             increase_button_element.click()
 
     def click_search(self):
-        search_button = self.find_element_by_css_selector(
+        search_button = self.find_element(By.CSS_SELECTOR,
             'button[type="submit"]'
         )
         search_button.click()

--- a/Bot Project/07 - Booking Filtrations/booking/booking_filtration.py
+++ b/Bot Project/07 - Booking Filtrations/booking/booking_filtration.py
@@ -8,7 +8,7 @@ class BookingFiltration:
         self.driver = driver
 
     def apply_star_rating(self, *star_values):
-        star_filtration_box = self.driver.find_element_by_id('filter_class')
+        star_filtration_box = self.driver.find_element(By.ID, 'filter_class')
         star_child_elements = star_filtration_box.find_elements_by_css_selector('*')
 
         for star_value in star_values:
@@ -18,7 +18,7 @@ class BookingFiltration:
 
 
     def sort_price_lowest_first(self):
-        element = self.driver.find_element_by_css_selector(
+        element = self.driver.find_element(By.CSS_SELECTOR,
             'li[data-id="price"]'
         )
         element.click()

--- a/Bot Project/08 - Execution from a CLI/booking/booking.py
+++ b/Bot Project/08 - Execution from a CLI/booking/booking.py
@@ -24,50 +24,50 @@ class Booking(webdriver.Chrome):
         self.get(const.BASE_URL)
 
     def change_currency(self, currency=None):
-        currency_element = self.find_element_by_css_selector(
+        currency_element = self.find_element(By.CSS_SELECTOR,
             'button[data-tooltip-text="Choose your currency"]'
         )
         currency_element.click()
 
-        selected_currency_element = self.find_element_by_css_selector(
+        selected_currency_element = self.find_element(By.CSS_SELECTOR,
             f'a[data-modal-header-async-url-param*="selected_currency={currency}"]'
         )
         selected_currency_element.click()
 
 
     def select_place_to_go(self, place_to_go):
-        search_field = self.find_element_by_id('ss')
+        search_field = self.find_element(By.ID, 'ss')
         search_field.clear()
         search_field.send_keys(place_to_go)
 
-        first_result = self.find_element_by_css_selector(
+        first_result = self.find_element(By.CSS_SELECTOR,
             'li[data-i="0"]'
         )
         first_result.click()
 
     def select_dates(self, check_in_date, check_out_date):
-        check_in_element = self.find_element_by_css_selector(
+        check_in_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_in_date}"]'
         )
         check_in_element.click()
 
-        check_out_element = self.find_element_by_css_selector(
+        check_out_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_out_date}"]'
         )
         check_out_element.click()
 
     def select_adults(self, count=1):
-        selection_element = self.find_element_by_id('xp__guests__toggle')
+        selection_element = self.find_element(By.ID, 'xp__guests__toggle')
         selection_element.click()
 
         while True:
-            decrease_adults_element = self.find_element_by_css_selector(
+            decrease_adults_element = self.find_element(By.CSS_SELECTOR,
                 'button[aria-label="Decrease number of Adults"]'
             )
             decrease_adults_element.click()
             #If the value of adults reaches 1, then we should get out
             #of the while loop
-            adults_value_element = self.find_element_by_id('group_adults')
+            adults_value_element = self.find_element(By.ID, 'group_adults')
             adults_value = adults_value_element.get_attribute(
                 'value'
             ) # Should give back the adults count
@@ -75,7 +75,7 @@ class Booking(webdriver.Chrome):
             if int(adults_value) == 1:
                 break
 
-        increase_button_element = self.find_element_by_css_selector(
+        increase_button_element = self.find_element(By.CSS_SELECTOR,
             'button[aria-label="Increase number of Adults"]'
         )
 
@@ -83,7 +83,7 @@ class Booking(webdriver.Chrome):
             increase_button_element.click()
 
     def click_search(self):
-        search_button = self.find_element_by_css_selector(
+        search_button = self.find_element(By.CSS_SELECTOR,
             'button[type="submit"]'
         )
         search_button.click()

--- a/Bot Project/08 - Execution from a CLI/booking/booking_filtration.py
+++ b/Bot Project/08 - Execution from a CLI/booking/booking_filtration.py
@@ -8,8 +8,8 @@ class BookingFiltration:
         self.driver = driver
 
     def apply_star_rating(self, *star_values):
-        star_filtration_box = self.driver.find_element_by_id('filter_class')
-        star_child_elements = star_filtration_box.find_elements_by_css_selector('*')
+        star_filtration_box = self.driver.find_element(By.ID, 'filter_class')
+        star_child_elements = star_filtration_box.find_elements(By.CSS_SELECTOR, '*')
 
         for star_value in star_values:
             for star_element in star_child_elements:
@@ -18,7 +18,7 @@ class BookingFiltration:
 
 
     def sort_price_lowest_first(self):
-        element = self.driver.find_element_by_css_selector(
+        element = self.driver.find_element(By.CSS_SELECTOR,
             'li[data-id="price"]'
         )
         element.click()

--- a/Bot Project/09 - Deal Reporting Part 1/booking/booking.py
+++ b/Bot Project/09 - Deal Reporting Part 1/booking/booking.py
@@ -2,7 +2,7 @@ import booking.constants as const
 import os
 from selenium import webdriver
 from booking.booking_filtration import BookingFiltration
-from booking.booking_report import BookingReport
+
 
 class Booking(webdriver.Chrome):
     def __init__(self, driver_path=r"C:\SeleniumDrivers",
@@ -24,50 +24,50 @@ class Booking(webdriver.Chrome):
         self.get(const.BASE_URL)
 
     def change_currency(self, currency=None):
-        currency_element = self.find_element_by_css_selector(
+        currency_element = self.find_element(By.CSS_SELECTOR,
             'button[data-tooltip-text="Choose your currency"]'
         )
         currency_element.click()
 
-        selected_currency_element = self.find_element_by_css_selector(
+        selected_currency_element = self.find_element(By.CSS_SELECTOR,
             f'a[data-modal-header-async-url-param*="selected_currency={currency}"]'
         )
         selected_currency_element.click()
 
 
     def select_place_to_go(self, place_to_go):
-        search_field = self.find_element_by_id('ss')
+        search_field = self.find_element(By.ID, 'ss')
         search_field.clear()
         search_field.send_keys(place_to_go)
 
-        first_result = self.find_element_by_css_selector(
+        first_result = self.find_element(By.CSS_SELECTOR,
             'li[data-i="0"]'
         )
         first_result.click()
 
     def select_dates(self, check_in_date, check_out_date):
-        check_in_element = self.find_element_by_css_selector(
+        check_in_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_in_date}"]'
         )
         check_in_element.click()
 
-        check_out_element = self.find_element_by_css_selector(
+        check_out_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_out_date}"]'
         )
         check_out_element.click()
 
     def select_adults(self, count=1):
-        selection_element = self.find_element_by_id('xp__guests__toggle')
+        selection_element = self.find_element(By.ID, 'xp__guests__toggle')
         selection_element.click()
 
         while True:
-            decrease_adults_element = self.find_element_by_css_selector(
+            decrease_adults_element = self.find_element(By.CSS_SELECTOR,
                 'button[aria-label="Decrease number of Adults"]'
             )
             decrease_adults_element.click()
             #If the value of adults reaches 1, then we should get out
             #of the while loop
-            adults_value_element = self.find_element_by_id('group_adults')
+            adults_value_element = self.find_element(By.ID, 'group_adults')
             adults_value = adults_value_element.get_attribute(
                 'value'
             ) # Should give back the adults count
@@ -75,7 +75,7 @@ class Booking(webdriver.Chrome):
             if int(adults_value) == 1:
                 break
 
-        increase_button_element = self.find_element_by_css_selector(
+        increase_button_element = self.find_element(By.CSS_SELECTOR,
             'button[aria-label="Increase number of Adults"]'
         )
 
@@ -83,7 +83,7 @@ class Booking(webdriver.Chrome):
             increase_button_element.click()
 
     def click_search(self):
-        search_button = self.find_element_by_css_selector(
+        search_button = self.find_element(By.CSS_SELECTOR,
             'button[type="submit"]'
         )
         search_button.click()
@@ -95,7 +95,7 @@ class Booking(webdriver.Chrome):
         filtration.sort_price_lowest_first()
 
     def report_results(self):
-        hotel_boxes = self.find_element_by_id(
+        hotel_boxes = self.find_element(By.ID,
             'hotellist_inner'
         )
 

--- a/Bot Project/09 - Deal Reporting Part 1/booking/booking_filtration.py
+++ b/Bot Project/09 - Deal Reporting Part 1/booking/booking_filtration.py
@@ -8,8 +8,8 @@ class BookingFiltration:
         self.driver = driver
 
     def apply_star_rating(self, *star_values):
-        star_filtration_box = self.driver.find_element_by_id('filter_class')
-        star_child_elements = star_filtration_box.find_elements_by_css_selector('*')
+        star_filtration_box = self.driver.find_element(By.ID, 'filter_class')
+        star_child_elements = star_filtration_box.find_elements(By.CSS_SELECTOR, '*')
 
         for star_value in star_values:
             for star_element in star_child_elements:
@@ -18,7 +18,7 @@ class BookingFiltration:
 
 
     def sort_price_lowest_first(self):
-        element = self.driver.find_element_by_css_selector(
+        element = self.driver.find_element(By.CSS_SELECTOR,
             'li[data-id="price"]'
         )
         element.click()

--- a/Bot Project/09 - Deal Reporting Part 1/booking/booking_report.py
+++ b/Bot Project/09 - Deal Reporting Part 1/booking/booking_report.py
@@ -9,13 +9,13 @@ class BookingReport:
         self.deal_boxes = self.pull_deal_boxes()
 
     def pull_deal_boxes(self):
-        return self.boxes_section_element.find_elements_by_class_name(
+        return self.boxes_section_element.find_elements(By.CLASS_NAME,
             'sr_property_block'
         )
 
     def pull_titles(self):
         for deal_box in self.deal_boxes:
-            hotel_name = deal_box.find_element_by_class_name(
+            hotel_name = deal_box.find_element(By.CLASS_NAME,
                 'sr-hotel__name'
             ).get_attribute('innerHTML').strip()
             print(hotel_name)

--- a/Bot Project/10 - Deal Reporting Part 2/booking/booking.py
+++ b/Bot Project/10 - Deal Reporting Part 2/booking/booking.py
@@ -2,8 +2,7 @@ import booking.constants as const
 import os
 from selenium import webdriver
 from booking.booking_filtration import BookingFiltration
-from booking.booking_report import BookingReport
-from prettytable import PrettyTable
+
 
 class Booking(webdriver.Chrome):
     def __init__(self, driver_path=r"C:\SeleniumDrivers",
@@ -25,50 +24,50 @@ class Booking(webdriver.Chrome):
         self.get(const.BASE_URL)
 
     def change_currency(self, currency=None):
-        currency_element = self.find_element_by_css_selector(
+        currency_element = self.find_element(By.CSS_SELECTOR,
             'button[data-tooltip-text="Choose your currency"]'
         )
         currency_element.click()
 
-        selected_currency_element = self.find_element_by_css_selector(
+        selected_currency_element = self.find_element(By.CSS_SELECTOR,
             f'a[data-modal-header-async-url-param*="selected_currency={currency}"]'
         )
         selected_currency_element.click()
 
 
     def select_place_to_go(self, place_to_go):
-        search_field = self.find_element_by_id('ss')
+        search_field = self.find_element(By.ID, 'ss')
         search_field.clear()
         search_field.send_keys(place_to_go)
 
-        first_result = self.find_element_by_css_selector(
+        first_result = self.find_element(By.CSS_SELECTOR,
             'li[data-i="0"]'
         )
         first_result.click()
 
     def select_dates(self, check_in_date, check_out_date):
-        check_in_element = self.find_element_by_css_selector(
+        check_in_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_in_date}"]'
         )
         check_in_element.click()
 
-        check_out_element = self.find_element_by_css_selector(
+        check_out_element = self.find_element(By.CSS_SELECTOR,
             f'td[data-date="{check_out_date}"]'
         )
         check_out_element.click()
 
     def select_adults(self, count=1):
-        selection_element = self.find_element_by_id('xp__guests__toggle')
+        selection_element = self.find_element(By.ID, 'xp__guests__toggle')
         selection_element.click()
 
         while True:
-            decrease_adults_element = self.find_element_by_css_selector(
+            decrease_adults_element = self.find_element(By.CSS_SELECTOR,
                 'button[aria-label="Decrease number of Adults"]'
             )
             decrease_adults_element.click()
             #If the value of adults reaches 1, then we should get out
             #of the while loop
-            adults_value_element = self.find_element_by_id('group_adults')
+            adults_value_element = self.find_element(By.ID, 'group_adults')
             adults_value = adults_value_element.get_attribute(
                 'value'
             ) # Should give back the adults count
@@ -76,7 +75,7 @@ class Booking(webdriver.Chrome):
             if int(adults_value) == 1:
                 break
 
-        increase_button_element = self.find_element_by_css_selector(
+        increase_button_element = self.find_element(By.CSS_SELECTOR,
             'button[aria-label="Increase number of Adults"]'
         )
 
@@ -84,7 +83,7 @@ class Booking(webdriver.Chrome):
             increase_button_element.click()
 
     def click_search(self):
-        search_button = self.find_element_by_css_selector(
+        search_button = self.find_element(By.CSS_SELECTOR,
             'button[type="submit"]'
         )
         search_button.click()
@@ -96,7 +95,7 @@ class Booking(webdriver.Chrome):
         filtration.sort_price_lowest_first()
 
     def report_results(self):
-        hotel_boxes = self.find_element_by_id(
+        hotel_boxes = self.find_element(By.ID,
             'hotellist_inner'
         )
 

--- a/Bot Project/10 - Deal Reporting Part 2/booking/booking_filtration.py
+++ b/Bot Project/10 - Deal Reporting Part 2/booking/booking_filtration.py
@@ -8,8 +8,8 @@ class BookingFiltration:
         self.driver = driver
 
     def apply_star_rating(self, *star_values):
-        star_filtration_box = self.driver.find_element_by_id('filter_class')
-        star_child_elements = star_filtration_box.find_elements_by_css_selector('*')
+        star_filtration_box = self.driver.find_element(By.ID, 'filter_class')
+        star_child_elements = star_filtration_box.find_elements(By.CSS_SELECTOR, '*')
 
         for star_value in star_values:
             for star_element in star_child_elements:
@@ -18,7 +18,7 @@ class BookingFiltration:
 
 
     def sort_price_lowest_first(self):
-        element = self.driver.find_element_by_css_selector(
+        element = self.driver.find_element(By.CSS_SELECTOR,
             'li[data-id="price"]'
         )
         element.click()

--- a/Bot Project/10 - Deal Reporting Part 2/booking/booking_report.py
+++ b/Bot Project/10 - Deal Reporting Part 2/booking/booking_report.py
@@ -9,7 +9,7 @@ class BookingReport:
         self.deal_boxes = self.pull_deal_boxes()
 
     def pull_deal_boxes(self):
-        return self.boxes_section_element.find_elements_by_class_name(
+        return self.boxes_section_element.find_elements(By.CLASS_NAME,
             'sr_property_block'
         )
 
@@ -17,10 +17,10 @@ class BookingReport:
         collection = []
         for deal_box in self.deal_boxes:
             # Pulling the hotel name
-            hotel_name = deal_box.find_element_by_class_name(
+            hotel_name = deal_box.find_element(By.CLASS_NAME,
                 'sr-hotel__name'
             ).get_attribute('innerHTML').strip()
-            hotel_price = deal_box.find_element_by_class_name(
+            hotel_price = deal_box.find_element(By.CLASS_NAME,
                 'bui-price-display__value'
             ).get_attribute('innerHTML').strip()
             hotel_score = deal_box.get_attribute(


### PR DESCRIPTION
Hey Jim,

This pull request addresses the deprecation of find_element_by_* commands in the latest Selenium Python libraries. The deprecation warning, DeprecationWarning: find_element_by_* commands are deprecated. Please use find_element() instead, indicates that these commands are no longer recommended for use.

To align with the latest changes and simplify the APIs across languages, the project has been updated to replace the deprecated find_element_by_* commands with the find_element() method.

Addresses Issue #2.

This update ensures compatibility with the latest Selenium Python libraries and promotes best practices for WebDriver automation.

As [AutomatedTester mentions](https://github.com/SeleniumHQ/selenium/issues/8806#issuecomment-711947184): This DeprecationWarning was the reflection of the changes made with respect to the decision to simplify the APIs across the languages and this does that.